### PR TITLE
Update rubocop v0.46 -> 0.47

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -113,7 +113,7 @@ Style/UnneededPercentQ:
 # assignments, where it should be aligned with the LHS.
 Lint/EndAlignment:
   Enabled: true
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license               = "MIT"
   spec.required_ruby_version = ">= 2.2.2"
 
-  spec.add_dependency "rubocop", "~> 0.46"
+  spec.add_dependency "rubocop", "~> 0.47"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name                  = "rubocop-rails"
-  spec.version               = "0.1.0"
+  spec.version               = "0.2.0"
   spec.summary               = "RuboCop for Rails"
   spec.description           = "Code style checking for Ruby on Rails project"
   spec.authors               = "Toshimaru"


### PR DESCRIPTION
`AlignWith` is now deprecated.