### PR TITLE
Adds node_modules to the exclusion list

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - '**/templates/**/*'
     - '**/vendor/**/*'
+    - '**/node_modules/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
 
 # Prefer &&/|| over and/or.


### PR DESCRIPTION
Since from Rails 5.1 come with yarn support, we need to ignore `node_modules`.

There can be some `.rb` files inside that. Example [node_modules/node-sass/src/libsass/extconf.rb](https://github.com/sass/libsass/blob/master/extconf.rb) if `node-sass` is added.