### PR TITLE
Exclude db/schema.rb

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -9,6 +9,7 @@ AllCops:
     - '**/vendor/**/.*'
     - '**/node_modules/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
+    - 'db/schema.rb'
 
 # Prefer &&/|| over and/or.
 Style/AndOr:


### PR DESCRIPTION
The file `db/schema.rb` is autogenerated so Rubocop shouldn't be instructing you to change it. With your defaults it has no offences but if some configuration is changed (eg, single_quotes for the Style/StringLiterals cop) it starts getting warnings. It would be better just to exclude it.