### PR TITLE
Add install generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem "rubocop-rails"
 
 ## Usage
 
-Add this line to your application's `.rubocop.yml`:
+Add this line to your application's `.rubocop.yml`, or just run `rails generate rubocop_rails:install`:
 
 ```yml
 inherit_gem:

--- a/lib/generators/rubocop_rails/install_generator.rb
+++ b/lib/generators/rubocop_rails/install_generator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails/generators/base"
+require "active_support/core_ext/string"
+
+module RubocopRails
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      desc "Creates a .rubocop.yml config file that inherits from the official Ruby on Rails .rubocop.yml."
+
+      def create_config_file
+        file_method = config_file_exists? ? :prepend : :create
+        send :"#{file_method}_file", config_file_path, config_file_content
+      end
+
+    private
+
+      def config_file_exists?
+        File.exist?(config_file_path)
+      end
+
+      def config_file_path
+        ".rubocop.yml"
+      end
+
+      def config_file_content
+        <<-EOS.strip_heredoc
+          inherit_gem:
+            rubocop-rails:
+              - config/rails.yml
+        EOS
+      end
+    end
+  end
+end

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2.2"
 
   spec.add_dependency "rubocop", "~> 0.49"
+  spec.add_dependency "railties", ">= 3.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Add a generator that creates/amends the `.rubocop.yml` configuration file. It can be run as follows:

```
$ rails generate rubocop_rails:install
```
