### PR TITLE
Move Lint\EndAlignment To Layout

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -144,7 +144,7 @@ Style/UnneededPercentQ:
 
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
   AutoCorrect: true


### PR DESCRIPTION
Lint\EndAlignment has been move to Layout in RuboCop as per https://github.com/bbatsov/rubocop/issues/4704