### PR TITLE
Import new `CustomCops/RefuteNot` cop from rails/rails

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,3 +1,5 @@
+require: custom_cops
+
 AllCops:
   TargetRubyVersion: 2.2
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
@@ -9,6 +11,11 @@ AllCops:
     - '**/vendor/**/.*'
     - '**/node_modules/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
+
+# Prefer assert_not_x over refute_x
+CustomCops/RefuteNot:
+  Include:
+    - '**/*_test.rb'
 
 # Prefer &&/|| over and/or.
 Style/AndOr:

--- a/lib/custom_cops.rb
+++ b/lib/custom_cops.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "custom_cops/refute_not"

--- a/lib/custom_cops/refute_not.rb
+++ b/lib/custom_cops/refute_not.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module CustomCops
+  # Enforces the use of `#assert_not` methods over `#refute` methods.
+  #
+  # @example
+  #   # bad
+  #   refute false
+  #   refute_empty [1, 2, 3]
+  #   refute_equal true, false
+  #
+  #   # good
+  #   assert_not false
+  #   assert_not_empty [1, 2, 3]
+  #   assert_not_equal true, false
+  #
+  class RefuteNot < RuboCop::Cop::Cop
+    MSG = "Prefer `%<assert_method>s` over `%<refute_method>s`"
+
+    CORRECTIONS = {
+      refute:             "assert_not",
+      refute_empty:       "assert_not_empty",
+      refute_equal:       "assert_not_equal",
+      refute_in_delta:    "assert_not_in_delta",
+      refute_in_epsilon:  "assert_not_in_epsilon",
+      refute_includes:    "assert_not_includes",
+      refute_instance_of: "assert_not_instance_of",
+      refute_kind_of:     "assert_not_kind_of",
+      refute_nil:         "assert_not_nil",
+      refute_operator:    "assert_not_operator",
+      refute_predicate:   "assert_not_predicate",
+      refute_respond_to:  "assert_not_respond_to",
+      refute_same:        "assert_not_same",
+      refute_match:       "assert_no_match"
+    }.freeze
+
+    OFFENSIVE_METHODS = CORRECTIONS.keys.freeze
+
+    def_node_matcher :offensive?, "(send nil? #offensive_method? ...)"
+
+    def on_send(node)
+      return unless offensive?(node)
+
+      message = offense_message(node.method_name)
+      add_offense(node, location: :selector, message: message)
+    end
+
+    def autocorrect(node)
+      ->(corrector) do
+        corrector.replace(
+          node.loc.selector,
+          CORRECTIONS[node.method_name]
+        )
+      end
+    end
+
+    private
+
+      def offensive_method?(method_name)
+        OFFENSIVE_METHODS.include?(method_name)
+      end
+
+      def offense_message(method_name)
+        format(
+          MSG,
+          refute_method: method_name,
+          assert_method: CORRECTIONS[method_name]
+        )
+      end
+  end
+end

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.description           = "RuboCop configuration which has the same code style checking as official Ruby on Rails"
   spec.authors               = "Toshimaru"
   spec.email                 = "me@toshimaru.net"
-  spec.files                 = Dir["README.md", "LICENSE", "config/*.yml"]
+  spec.files                 = Dir["README.md", "LICENSE", "config/*.yml", "lib/**/*"]
   spec.homepage              = "https://github.com/toshimaru/rubocop-rails"
   spec.license               = "MIT"
   spec.required_ruby_version = ">= 2.2.2"

--- a/test/custom_cops/refute_not_test.rb
+++ b/test/custom_cops/refute_not_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "support/cop_helper"
+require "./lib/custom_cops"
+
+class RefuteNotTest < ActiveSupport::TestCase
+  include CopHelper
+
+  setup do
+    @cop = CustomCops::RefuteNot.new
+  end
+
+  {
+    refute:             :assert_not,
+    refute_empty:       :assert_not_empty,
+    refute_equal:       :assert_not_equal,
+    refute_in_delta:    :assert_not_in_delta,
+    refute_in_epsilon:  :assert_not_in_epsilon,
+    refute_includes:    :assert_not_includes,
+    refute_instance_of: :assert_not_instance_of,
+    refute_kind_of:     :assert_not_kind_of,
+    refute_nil:         :assert_not_nil,
+    refute_operator:    :assert_not_operator,
+    refute_predicate:   :assert_not_predicate,
+    refute_respond_to:  :assert_not_respond_to,
+    refute_same:        :assert_not_same,
+    refute_match:       :assert_no_match
+  }.each do |refute_method, assert_method|
+    test "rejects `#{refute_method}` with a single argument" do
+      inspect_source(@cop, "#{refute_method} a")
+      assert_offense @cop, offense_message(refute_method, assert_method)
+    end
+
+    test "rejects `#{refute_method}` with multiple arguments" do
+      inspect_source(@cop, "#{refute_method} a, b, c")
+      assert_offense @cop, offense_message(refute_method, assert_method)
+    end
+
+    test "autocorrects `#{refute_method}` with a single argument" do
+      corrected = autocorrect_source(@cop, "#{refute_method} a")
+      assert_equal "#{assert_method} a", corrected
+    end
+
+    test "autocorrects `#{refute_method}` with multiple arguments" do
+      corrected = autocorrect_source(@cop, "#{refute_method} a, b, c")
+      assert_equal "#{assert_method} a, b, c", corrected
+    end
+
+    test "accepts `#{assert_method}` with a single argument" do
+      inspect_source(@cop, "#{assert_method} a")
+      assert_empty @cop.offenses
+    end
+
+    test "accepts `#{assert_method}` with multiple arguments" do
+      inspect_source(@cop, "#{assert_method} a, b, c")
+      assert_empty @cop.offenses
+    end
+  end
+
+  private
+
+    def assert_offense(cop, expected_message)
+      assert_not_empty cop.offenses
+
+      offense = cop.offenses.first
+      carets = "^" * offense.column_length
+
+      assert_equal expected_message, "#{carets} #{offense.message}"
+    end
+
+    def offense_message(refute_method, assert_method)
+      carets = "^" * refute_method.to_s.length
+      "#{carets} Prefer `#{assert_method}` over `#{refute_method}`"
+    end
+end

--- a/test/support/cop_helper.rb
+++ b/test/support/cop_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "active_support"
+require "rubocop"
+
+module CopHelper
+  def inspect_source(cop, source)
+    processed_source = parse_source(source)
+    raise "Error parsing example code" unless processed_source.valid_syntax?
+    investigate(cop, processed_source)
+    processed_source
+  end
+
+  def autocorrect_source(cop, source)
+    cop.instance_variable_get(:@options)[:auto_correct] = true
+    processed_source = inspect_source(cop, source)
+    rewrite(cop, processed_source)
+  end
+
+  private
+    TARGET_RUBY_VERSION = 2.4
+
+    def parse_source(source)
+      RuboCop::ProcessedSource.new(source, TARGET_RUBY_VERSION)
+    end
+
+    def rewrite(cop, processed_source)
+      RuboCop::Cop::Corrector.new(processed_source.buffer, cop.corrections)
+        .rewrite
+    end
+
+    def investigate(cop, processed_source)
+      RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
+        .investigate(processed_source)
+    end
+end


### PR DESCRIPTION
This PR imports rails/rails#32441.

IMO, I think that it would be more plausible to write `require: rubocop-rails` instead of `require: custom_cops` in config/rails.yml, but first of all this PR writes `require: custom_cops` according to upstream.