### PR TITLE
Update command to install rubocop_rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gem "rubocop-rails"
 
 ## Usage
 
-Add this line to your application's `.rubocop.yml`, or just run `rails generate rubocop_rails:install`:
+Add this line to your application's `.rubocop.yml`, or just run `rails generate rubocop_rails_config:install`:
 
 ```yml
 inherit_gem:


### PR DESCRIPTION
Running `rails generate rubocop_rails:install` I get this error: 

> Could not find generator `rubocop_rails:install`. Maybe you meant `rubocop_rails_config:install`

In this PR, Update `rubocop_rails:install` to `rubocop_rails_config:install`.

This`s my environment:
Ruby 2.5.3p105
Rails 5.2.2